### PR TITLE
Fix gevent startup issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,8 @@
 ''' Game entrypoint '''
 
+from gevent import monkey
+monkey.patch_all()
+
 import game.telnet as telnet
 
 if __name__ == '__main__':

--- a/game/telnet.py
+++ b/game/telnet.py
@@ -4,10 +4,8 @@ import logging
 import socket
 
 from gevent import Greenlet
-from gevent import monkey
-from game.game import GameSession
 
-monkey.patch_all()
+from game.game import GameSession
 
 class TelnetServer():
     ''' Listener handling for Telnet server, creates session greenlets '''


### PR DESCRIPTION
Gevent tends to not be very happy if the monkey patching isn't
done at a certain time. The import order changes done for the
Pylint fixes got Gevent into a bad state, where the interpreter
just dies.

Move the monkey patching to the top of the entrypoint script,
which will also keep Pylint happy.