### PR TITLE
Combine common code b/w Monster and User

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - run: "apk update && apk add --no-cache python3 py3-pip && pip3 install pylint"
 
       # Pylint
-      - run: "pylint -d import-error,duplicate-code **/**.py"
+      - run: "pylint -d import-error **/**.py"

--- a/game/entity.py
+++ b/game/entity.py
@@ -1,0 +1,23 @@
+''' Contains common code across all entities '''
+
+import random
+
+class Entity:
+    ''' Defines an entity '''
+
+    #pylint: disable=unused-argument
+    def __init__(self, name, health=100, strength=10, **kwargs):
+        # **kwargs required as DB stores extra fields.
+        self.name = name
+        self.health = health
+        self.strength = strength
+
+    def lose(self, amount):
+        ''' Subtracts an amount from health '''
+
+        self.health = self.health - amount
+
+    def hit(self):
+        ''' Determines amount to hit '''
+
+        return random.randrange(self.strength/2, self.strength)

--- a/game/monster.py
+++ b/game/monster.py
@@ -1,21 +1,6 @@
 ''' Contains code related to monsters '''
 
-import random
+from game.entity import Entity
 
-class Monster():
-    ''' Monster '''
-
-    def __init__(self, name, health, strength):
-        self.name = name
-        self.health = health
-        self.strength = strength
-
-    def lose(self, amount):
-        ''' Subtracts an amount from health '''
-
-        self.health = self.health - amount
-
-    def hit(self):
-        ''' Determines amount to hit '''
-
-        return random.randint(self.strength/2, self.strength)
+class Monster(Entity):
+    ''' Monster placeholder '''


### PR DESCRIPTION
Using `**kwargs`, we can easily pass all the parameters to the `User`
constructor in a dictionary without requiring the constructor to
contain parameters for the values that both it _and_ `Entity` need.
Whatever User needs will not be in the `**kwargs` passed to Entity,
so Entity only gets the leftovers.
* This model should help with instances of Pylint too-many-arguments
going forward.

As part of these changes, I've also made it so that `User` is
instantiated directly using the DB document, as well as the `Monster`
being instantiated directly using the values from the YAML. This
requires that `User`/`Monster`/`Entity` member names match DB/YAML field names,
though transform functions could easily be created later on to switch
between what the YAML/DB needs and what the code needs. For the time
being, the simplicity is nice as I'm adding new fields, etc., though
the negatives are clear with an approach like this. It should not be
something that stays indefinitely.