### PR TITLE
Eliminate direct requirements in both structure and naming

### DIFF
--- a/game/constants.py
+++ b/game/constants.py
@@ -1,0 +1,21 @@
+''' Constants to use throughout codebase '''
+
+# Constants mapping between DB/config field names and parameter names.
+# **kwargs used to cut down on number of parameters for User, etc.,
+# and these are used to build those **kwargs. Constants used to enforce
+# common naming between DB and config as well.
+
+DB_NAME = 'name'
+NAME = 'name'
+
+DB_CLS = 'cls'
+CLS = 'cls'
+
+DB_KEY = 'key'
+KEY = 'key'
+
+DB_HP = 'health'
+HP = 'health'
+
+DB_STR = 'strength'
+STR = 'strength'

--- a/game/entity.py
+++ b/game/entity.py
@@ -6,8 +6,9 @@ class Entity:
     ''' Defines an entity '''
 
     #pylint: disable=unused-argument
-    def __init__(self, name, health=100, strength=10, **kwargs):
-        # **kwargs required as DB stores extra fields.
+    def __init__(self, name, health=100, strength=10):
+        ''' Param names match constants.py '''
+
         self.name = name
         self.health = health
         self.strength = strength

--- a/game/monster.py
+++ b/game/monster.py
@@ -1,6 +1,20 @@
 ''' Contains code related to monsters '''
 
+from game.constants import \
+    DB_NAME, DB_STR, DB_HP, NAME, STR, HP
 from game.entity import Entity
 
 class Monster(Entity):
-    ''' Monster placeholder '''
+    ''' Monster '''
+
+    @staticmethod
+    def cfg_to_monster(**kwargs):
+        ''' Converts configuration monster to Monster object '''
+
+        data = {
+            NAME: kwargs[DB_NAME],
+            STR: kwargs[DB_STR],
+            HP: kwargs[DB_HP]
+        }
+
+        return Monster(**data)


### PR DESCRIPTION
Currently it is required that the DB and YAML not only have a
flat structure, but that the field names match parameter names.

These changes incorporate transformation functions to avoid this,
and introduce constants to enforce common naming across the entire
system.

This is by no means the ultimate replacement to a full-fledged
ORM! With that said, introducing an ORM doesn't seem entirely
necessary at this point given there is only 1 table. Also,
given that the project also uses YAML, 2 ORMs would be required
to avoid this kind of stuff.

For the time being, this offers decent enough flexibility in the
absence of an ORM(s).