### PR TITLE
Add YAML schema validation using Yamale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM alpine
 RUN apk update && \
     apk add --no-cache python3 python3-dev make \
                        musl-dev libffi-dev py3-pip gcc
-RUN pip3 install gevent pycryptodome pymongo pyyaml
+RUN pip3 install gevent pycryptodome pymongo pyyaml yamale
 
 ENV PYTHONUNBUFFERED=1
 EXPOSE 5555
 
 COPY game /game
-COPY config.yml /game
+COPY config.yml schema.yml /game/
 COPY app.py /
 
 CMD ["python3", "app.py"]

--- a/schema.yml
+++ b/schema.yml
@@ -1,0 +1,22 @@
+monster: list(include('monster_type'), min=1)
+map: list(include('map_type'), min=1)
+player: include('player_type')
+---
+monster_type:
+    name: str(min=1)
+    strength: int(min=1)
+    health: int(min=1)
+
+map_type:
+    name: str(min=1)
+    monsters: list(str(min=1), min=1)
+    dim: include('dim_type')
+
+dim_type:
+    xMin: int(min=0)
+    yMin: int(min=0)
+    xMax: int(min=0)
+    yMax: int(min=0)
+
+player_type:
+    class: list(str(min=1), min=1)


### PR DESCRIPTION
[`yamale`](https://github.com/23andMe/Yamale) allows us to neatly code up a schema to validate the structure of the configuration YAML.

The `[0][0]` thing is a little funky, but it seemed to be the only way I could tell to get the parsed config file.

**This ensures that _any_ class with a `from_cfg`** static method, which indicates that it's loaded from the configuration YAML, will have the required fields, appropriate values, etc., so there's no need to worry in doing any `**kwargs` magic (if it applies to the configuration file).

To ensure total YAML validation (beyond structure), I think the final thing left to do is to validate that all monsters referenced in the map definitions actually exist in the YAML. It might be possible to do this sort of check with Yamale.

The document preceding the `---` describes the base schema, ie. the outermost members of the YAML. The document following describes the includes, which are any custom non-default types (default example would be `int`), which may or may not be nested. Custom type definitions cannot be included in the base schema.

Implements #18